### PR TITLE
Unhandled Exception(setState called after dispose)

### DIFF
--- a/lib/loaders/color_loader.dart
+++ b/lib/loaders/color_loader.dart
@@ -16,6 +16,7 @@ class _ColorLoaderState extends State<ColorLoader>
     with SingleTickerProviderStateMixin {
   final List<Color> colors;
   final Duration duration;
+  Timer timer;
 
   _ColorLoaderState(this.colors, this.duration);
 
@@ -59,7 +60,7 @@ class _ColorLoaderState extends State<ColorLoader>
 
     tweenIndex = 0;
 
-    Timer.periodic(duration, (Timer t) {
+    timer = Timer.periodic(duration, (Timer t) {
       setState(() {
         tweenIndex = (tweenIndex + 1) % colors.length;
       });
@@ -83,6 +84,7 @@ class _ColorLoaderState extends State<ColorLoader>
   @override
   void dispose() {
     super.dispose();
+    timer.cancel();
     controller.dispose();
   }
 }

--- a/lib/loaders/color_loader.dart
+++ b/lib/loaders/color_loader.dart
@@ -83,8 +83,8 @@ class _ColorLoaderState extends State<ColorLoader>
 
   @override
   void dispose() {
-    super.dispose();
     timer.cancel();
     controller.dispose();
+    super.dispose();
   }
 }


### PR DESCRIPTION
the color loader was giving Unhandled exceptions when you use it until something loading
because it will keep listening to changes and timer ticks ,,
just added timer.cancel to stop listening and setstating

ERROR i was getting


```
E/flutter (21645): [ERROR:flutter/shell/common/shell.cc(181)] Dart Error: Unhandled exception:
E/flutter (21645): setState() called after dispose(): _ColorLoaderState#c1d8c(lifecycle state: defunct, not mounted, ticker inactive)
E/flutter (21645): This error happens if you call setState() on a State object for a widget that no longer appears in the widget tree (e.g., whose parent widget no longer includes the widget in its build). This error can occur when code calls setState() from a timer or an animation callback. The preferred solution is to cancel the timer or stop listening to the animation in the dispose() callback. Another solution is to check the "mounted" property of this object before calling setState() to ensure the object is still in the tree.
E/flutter (21645): This error might indicate a memory leak if setState() is being called because another object is retaining a reference to this State object after it has been removed from the tree. To avoid memory leaks, consider breaking the reference to this object during dispose().
E/flutter (21645): #0      State.setState.<anonymous closure> (package:flutter/src/widgets/framework.dart:1098:9)
E/flutter (21645): #1      State.setState (package:flutter/src/widgets/framework.dart:1124:6)
E/flutter (21645): #2      _ColorLoaderState.initState.<anonymous closure> (package:project/Animation/color_loader.dart:69:7)
E/flutter (21645): #3      _Timer._runTimers (dart:isolate/runtime/libtimer_impl.dart:382:19)
E/flutter (21645): #4      _Timer._handleMessage (dart:isolate/runtime/libtimer_impl.dart:416:5)
E/flutter (21645): #5      _RawReceivePortImpl._handleMessage (dart:isolate/runtime/libisolate_patch.dart:171:12)
```