### PR TITLE
remove redundant text color param in buttons

### DIFF
--- a/lib/Examples/buttons.dart
+++ b/lib/Examples/buttons.dart
@@ -17,7 +17,6 @@ class ButtonExample extends StatelessWidget {
             buttonText: Text("LOGIN", style: TextStyle(
                 color: Colors.white
             ),),
-            textColor: Colors.white,
           ),
 
           SimpleRoundIconButton(
@@ -25,7 +24,6 @@ class ButtonExample extends StatelessWidget {
             buttonText: Text("SEND EMAIL", style: TextStyle(
                 color: Colors.white
             ),),
-            textColor: Colors.white,
             icon: Icon(Icons.email),
           ),
 
@@ -34,7 +32,6 @@ class ButtonExample extends StatelessWidget {
             buttonText: Text("LISTEN TO MUSIC", style: TextStyle(
                 color: Colors.white
             ),),
-            textColor: Colors.white,
             icon: Icon(Icons.headset_mic),
             iconAlignment: Alignment.centerRight,
           ),
@@ -44,7 +41,6 @@ class ButtonExample extends StatelessWidget {
             buttonText: Text("SHARE ON SOCIAL", style: TextStyle(
                 color: Colors.white
             ),),
-            textColor: Colors.white,
             icon: Icon(Icons.share),
           ),
 
@@ -101,7 +97,6 @@ class ButtonExample extends StatelessWidget {
                   buttonText: Text("PLAY", style: TextStyle(
                       color: Colors.white
                   ),),
-                  textColor: Colors.white,
                   icon: Icon(Icons.play_arrow),
                   iconAlignment: Alignment.centerRight,
                 ),
@@ -114,7 +109,6 @@ class ButtonExample extends StatelessWidget {
                   buttonText: Text("OK", style: TextStyle(
                       color: Colors.green
                   ),),
-                  textColor: Colors.white,
                 ),
               ),
             ],

--- a/lib/buttons/simple_round_button.dart
+++ b/lib/buttons/simple_round_button.dart
@@ -4,13 +4,11 @@ class SimpleRoundButton extends StatelessWidget {
 
   final Color backgroundColor;
   final Text buttonText;
-  final Color textColor;
   final Function onPressed;
 
   SimpleRoundButton({
     this.backgroundColor,
     this.buttonText,
-    this.textColor,
     this.onPressed
   });
 

--- a/lib/buttons/simple_round_icon_button.dart
+++ b/lib/buttons/simple_round_icon_button.dart
@@ -4,7 +4,6 @@ class SimpleRoundIconButton extends StatelessWidget {
 
   final Color backgroundColor;
   final Text buttonText;
-  final Color textColor;
   final Icon icon;
   final Color iconColor;
   final Alignment iconAlignment;
@@ -13,7 +12,6 @@ class SimpleRoundIconButton extends StatelessWidget {
   SimpleRoundIconButton({
     this.backgroundColor = Colors.redAccent,
     this.buttonText = const Text("REQUIRED TEXT"),
-    this.textColor = Colors.white,
     this.icon = const Icon(Icons.email),
     this.iconColor,
     this.iconAlignment = Alignment.centerLeft,


### PR DESCRIPTION
The `textColor` param is not used in button widgets, instead, it should be defined in `Text()`, this param confuses the user.